### PR TITLE
Remove Python 2 compatibility lines

### DIFF
--- a/neva/adjust.py
+++ b/neva/adjust.py
@@ -3,7 +3,6 @@ which external assets can be adjusted such that the fixed-point equity is
 initially consistent with its naive value.
 """
 
-from __future__ import division
 from .bank import Bank
 from .bankingsystem import BankingSystem
     

--- a/neva/bank.py
+++ b/neva/bank.py
@@ -63,7 +63,7 @@ import numbers
 
 
 # pylint: disable=too-many-instance-attributes
-class Bank(object):
+class Bank:
     """Bank with balance sheet and valuation functions.
     
     Attributes:

--- a/neva/bank.py
+++ b/neva/bank.py
@@ -59,7 +59,6 @@ References:
         Mathematical Finance, https://doi.org/10.1111/mafi.12272
 """
 
-from __future__ import division
 import numbers
 
 

--- a/neva/bankingsystem.py
+++ b/neva/bankingsystem.py
@@ -5,7 +5,7 @@ import collections
 from .bank import Bank
 
 
-class BankingSystem(object):
+class BankingSystem:
     """Collection of banks.
     
     This container allows to perform operations that require access to data of

--- a/neva/bankingsystem.py
+++ b/neva/bankingsystem.py
@@ -1,7 +1,6 @@
 """Collection of banks constituing a banking system.
 """
 
-from __future__ import division
 import collections
 from .bank import Bank
 

--- a/neva/exteval.py
+++ b/neva/exteval.py
@@ -18,7 +18,6 @@ References:
         Mathematical Finance, https://doi.org/10.1111/mafi.12272
 """
 
-from __future__ import division
 from .ibeval import lognormal_pd, blackcox_pd
 
 

--- a/neva/gbm.py
+++ b/neva/gbm.py
@@ -2,7 +2,6 @@
 which external assets follow a Geometric Brownian Motion.
 """
 
-from __future__ import division
 import math
 from .adjust import BankAdjust, BankingSystemAdjust
 

--- a/neva/ibeval.py
+++ b/neva/ibeval.py
@@ -20,7 +20,6 @@ References:
         Mathematical Finance, https://doi.org/10.1111/mafi.12272
 """
 
-from __future__ import division
 import math
 
 

--- a/neva/ibeval_lender.py
+++ b/neva/ibeval_lender.py
@@ -17,4 +17,3 @@ the lender.
 Presently lender interbank valuation functions are not used or implemented.
 """
 
-from __future__ import division

--- a/neva/parse.py
+++ b/neva/parse.py
@@ -1,6 +1,5 @@
 """Parse various inputs that store information on the banking system."""
 
-from __future__ import division
 import json
 import sys
 import csv

--- a/neva/tests/test_bank.py
+++ b/neva/tests/test_bank.py
@@ -2,7 +2,6 @@
 ...
 """
 
-from __future__ import division
 import unittest
 import neva
 


### PR DESCRIPTION
Using Python 2 is strongly discouraged at this point in time.